### PR TITLE
Upgrade deprecated filter flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,5 @@ __pycache__
 # Simulation / Native
 eeprom.dat
 imgui.ini
+
+.fake

--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -15,7 +15,7 @@
 [common_avr8]
 build_flags       = ${common.build_flags} -Wl,--relax
 board_build.f_cpu = 16000000L
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+build_src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
 # ATmega2560

--- a/ini/due.ini
+++ b/ini/due.ini
@@ -18,7 +18,7 @@
 [env:DUE]
 platform   = atmelsam
 board      = due
-src_filter = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
+build_src_filter = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
 
 [env:DUE_USB]
 platform = atmelsam

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -16,7 +16,7 @@
 platform      = espressif32@2.1.0
 board         = esp32dev
 build_flags   = ${common.build_flags} -DCORE_DEBUG_LEVEL=0
-src_filter    = ${common.default_src_filter} +<src/HAL/ESP32>
+build_src_filter    = ${common.default_src_filter} +<src/HAL/ESP32>
 lib_ignore    = NativeEthernet
 upload_speed  = 500000
 monitor_speed = 250000

--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -20,7 +20,7 @@ lib_ldf_mode      = off
 lib_compat_mode   = strict
 extra_scripts     = ${common.extra_scripts}
   Marlin/src/HAL/LPC1768/upload_extra_script.py
-src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
+build_src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
 lib_deps          = ${common.lib_deps}
   Servo
 custom_marlin.USES_LIQUIDCRYSTAL =  arduino-libraries/LiquidCrystal@~1.0.7

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -16,11 +16,11 @@
 platform        = native
 framework       =
 build_flags     = -D__PLAT_LINUX__ -std=gnu++17 -ggdb -g -lrt -lpthread -D__MARLIN_FIRMWARE__ -Wno-expansion-to-defined
-src_build_flags = -Wall -IMarlin/src/HAL/LINUX/include
+build_src_flags = -Wall -IMarlin/src/HAL/LINUX/include
 build_unflags   = -Wall
 lib_ldf_mode    = off
 lib_deps        =
-src_filter      = ${common.default_src_filter} +<src/HAL/LINUX>
+build_src_filter      = ${common.default_src_filter} +<src/HAL/LINUX>
 
 #
 # Native Simulation
@@ -38,11 +38,11 @@ src_filter      = ${common.default_src_filter} +<src/HAL/LINUX>
 platform          = native
 framework         =
 build_flags       = ${common.build_flags} -std=gnu++17 -D__PLAT_NATIVE_SIM__ -DU8G_HAL_LINKS -I/usr/include/SDL2 -IMarlin -IMarlin/src/HAL/NATIVE_SIM/include -IMarlin/src/HAL/NATIVE_SIM/u8g
-src_build_flags   = -Wall -Wno-expansion-to-defined -Wcast-align
+build_src_flags   = -Wall -Wno-expansion-to-defined -Wcast-align
 release_flags     = -g0 -O3 -flto
 debug_build_flags = -fstack-protector-strong -g -g3 -ggdb
 lib_compat_mode   = off
-src_filter        = ${common.default_src_filter} +<src/HAL/NATIVE_SIM>
+build_src_filter        = ${common.default_src_filter} +<src/HAL/NATIVE_SIM>
 
 lib_deps          = ${common.lib_deps}
   MarlinSimUI=https://github.com/p3p/MarlinSimUI/archive/master.zip
@@ -125,6 +125,6 @@ build_unflags   = ${simulator_macos.build_unflags}
 [env:simulator_windows]
 platform    = ${simulator_common.platform}
 extends     = simulator_common
-src_build_flags = ${simulator_common.src_build_flags} -fpermissive
+build_src_flags = ${simulator_common.src_build_flags} -fpermissive
 build_flags = ${simulator_common.build_flags} ${simulator_common.debug_build_flags} -IC:\\msys64\\mingw64\\include\\SDL2 -fno-stack-protector -Wl,-subsystem,windows -ldl -lmingw32 -lSDL2main -lSDL2 -lSDL2_net -lopengl32 -lssp
 build_type = debug

--- a/ini/samd51.ini
+++ b/ini/samd51.ini
@@ -17,7 +17,7 @@ platform       = atmelsam
 board          = adafruit_grandcentral_m4
 build_flags    = ${common.build_flags} -std=gnu++17
 build_unflags  = -std=gnu++11
-src_filter     = ${common.default_src_filter} +<src/HAL/SAMD51>
+build_src_filter     = ${common.default_src_filter} +<src/HAL/SAMD51>
 lib_deps       = ${common.lib_deps}
   SoftwareSerialM
 extra_scripts  = ${common.extra_scripts}

--- a/ini/stm32f0.ini
+++ b/ini/stm32f0.ini
@@ -51,4 +51,4 @@ board       = malyanm300_f070cb
 build_flags = ${common_stm32.build_flags}
               -DHAL_PCD_MODULE_ENABLED -DDISABLE_GENERIC_SERIALUSB
               -DHAL_UART_MODULE_ENABLED
-src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
+build_src_filter  = ${common.default_src_filter} +<src/HAL/STM32>

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -28,7 +28,7 @@ board_build.core  = maple
 build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags} -DARDUINO_ARCH_STM32 -DMAPLE_STM32F1
 build_unflags     = -std=gnu11 -std=gnu++11
-src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
+build_src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore        = SPI, FreeRTOS701, FreeRTOS821
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -222,7 +222,7 @@ board       = malyanm200_f103cb
 build_flags = ${common_stm32.build_flags}
               -DHAL_PCD_MODULE_ENABLED -DDISABLE_GENERIC_SERIALUSB
               -DHAL_UART_MODULE_ENABLED
-src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
+build_src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
 
 #
 # FLYmaker FLY Mini (STM32F103RCT6)

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -24,7 +24,7 @@ lib_ignore = ${env:common_avr8.lib_ignore}, NativeEthernet
 [env:teensy31]
 platform      = teensy@~4.12.0
 board         = teensy31
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY31_32>
+build_src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY31_32>
 lib_ignore    = NativeEthernet
 
 #
@@ -33,13 +33,13 @@ lib_ignore    = NativeEthernet
 [env:teensy35]
 platform      = teensy@~4.12.0
 board         = teensy35
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
+build_src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
 lib_ignore    = NativeEthernet
 
 [env:teensy36]
 platform      = teensy@~4.12.0
 board         = teensy36
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
+build_src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
 lib_ignore    = NativeEthernet
 
 #
@@ -48,4 +48,4 @@ lib_ignore    = NativeEthernet
 [env:teensy41]
 platform      = teensy@~4.12.0
 board         = teensy41
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY40_41>
+build_src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY40_41>

--- a/platformio.ini
+++ b/platformio.ini
@@ -256,15 +256,11 @@ extra_scripts = ${common.extra_scripts}
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 monitor_speed = 250000
-monitor_flags =
-  --quiet
-  --echo
-  --eol
-    LF
-  --filter
-    colorize
-  --filter
-    time
+monitor_filters = default, colorize, time
+monitor_eol = LF
+monitor_echo = yes
+# monitor_flags =
+#   --quiet
 
 #
 # Just print the dependency tree
@@ -273,4 +269,4 @@ monitor_flags =
 platform    = atmelavr
 board       = megaatmega2560
 build_flags = -c -H -std=gnu++11 -Wall -Os -D__MARLIN_FIRMWARE__
-src_filter  = +<src/MarlinCore.cpp>
+build_src_filter  = +<src/MarlinCore.cpp>


### PR DESCRIPTION
get rid of warnings due to use of deprecated platform.io flags